### PR TITLE
minor fix: naming convention and prefix missing

### DIFF
--- a/iai_boxy_controller_configuration/config/boxy_l_gripper_pos_controller.yaml
+++ b/iai_boxy_controller_configuration/config/boxy_l_gripper_pos_controller.yaml
@@ -1,7 +1,7 @@
 l_gripper_state_separator:
   joint_names:
-    - left_gripper_base_joint_gripper_left
-    - left_gripper_base_joint_gripper_right
+    - left_gripper_base_gripper_left_joint
+    - left_gripper_base_gripper_right_joint
 l_gripper_pos_controller:
   vel_command_type: MultiJointVelocityCommand
   max_speed: 1.2

--- a/iai_boxy_controller_configuration/config/boxy_r_gripper_pos_controller.yaml
+++ b/iai_boxy_controller_configuration/config/boxy_r_gripper_pos_controller.yaml
@@ -1,7 +1,7 @@
 r_gripper_state_separator:
   joint_names:
-    - right_gripper_base_joint_gripper_left
-    - right_gripper_base_joint_gripper_right
+    - right_gripper_base_gripper_left_joint
+    - right_gripper_base_gripper_right_joint
 r_gripper_pos_controller:
   vel_command_type: MultiJointVelocityCommand
   max_speed: 1.2

--- a/iai_boxy_controller_configuration/config/boxy_sim_vel_controllers.yaml
+++ b/iai_boxy_controller_configuration/config/boxy_sim_vel_controllers.yaml
@@ -59,17 +59,17 @@ torso_vel:
 r_gripper_vel:
   type: "iai_robot_mechanism_controllers/MultiJointVelocityController"
   joints:
-    - right_gripper_base_joint_gripper_left
-    - right_gripper_base_joint_gripper_right
+    - right_gripper_base_gripper_left_joint
+    - right_gripper_base_gripper_right_joint
   gains:
-    right_gripper_base_joint_gripper_left: *pid_gains
-    right_gripper_base_joint_gripper_right: *pid_gains
+    right_gripper_base_gripper_left_joint: *pid_gains
+    right_gripper_base_gripper_right_joint: *pid_gains
 
 l_gripper_vel:
   type: "iai_robot_mechanism_controllers/MultiJointVelocityController"
   joints:
-    - left_gripper_base_joint_gripper_left
-    - left_gripper_base_joint_gripper_right
+    - left_gripper_base_gripper_left_joint
+    - left_gripper_base_gripper_right_joint
   gains:
-    left_gripper_base_joint_gripper_left: *pid_gains
-    left_gripper_base_joint_gripper_right: *pid_gains
+    left_gripper_base_gripper_left_joint: *pid_gains
+    left_gripper_base_gripper_right_joint: *pid_gains

--- a/iai_boxy_controller_configuration/scripts/wsg_50_controller.py
+++ b/iai_boxy_controller_configuration/scripts/wsg_50_controller.py
@@ -20,7 +20,7 @@
 
 import rospy
 import sys
-from wsg_50_msgs.msg import SpeedCmd, PositionCmd
+from iai_wsg_50_msgs.msg import SpeedCmd, PositionCmd
 from std_msgs.msg import Float32MultiArray, Header
 from iai_control_utils.jcontroller import JController
 

--- a/iai_wsg_50_description/urdf/wsg_50.urdf.xacro
+++ b/iai_wsg_50_description/urdf/wsg_50.urdf.xacro
@@ -55,7 +55,7 @@
      <limit lower="-0.055" upper="-0.0027" effort="1.0" velocity="0.42"/>
      <origin xyz="0 0 0" rpy="0 0 0" />      <!--origin xyz="-0.0067 0 0.049" rpy="0 0 0" /-->
      <parent link="${name}_base_link"/>
-     <child link="${name}_gripper_left" />
+     <child link="${name}_gripper_left_link" />
      <dynamics friction="100" damping="100" />
      <axis xyz="1 0 0"/>
      <!-- <limit effort="100" velocity="100"/> -->
@@ -68,7 +68,7 @@
      <motorTorqueConstant>1</motorTorqueConstant>
   </transmission>
 
-  <link name="${name}_gripper_left">
+  <link name="${name}_gripper_left_link">
       <inertial>
           <mass value="0.1" />
           <origin xyz="0 0 0" />
@@ -98,7 +98,7 @@
      <contact_coefficients kd="1.0" kp="1000.0" mu="0"/>
   </link>
 
-  <gazebo reference="${name}_gripper_left">
+  <gazebo reference="${name}_gripper_left_link">
     <material>Gazebo/Blue</material>
     <turnGravityOff>false</turnGravityOff>
   </gazebo>
@@ -108,14 +108,14 @@
 
   <joint name="${name}_guide_joint_finger_left" type="fixed">
      <origin xyz="0 0 0.023" rpy="0 0 0" />
-     <parent link="${name}_gripper_left"/>
-     <child link="${name}_finger_left" />
+     <parent link="${name}_gripper_left_link"/>
+     <child link="${name}_finger_left_link" />
      <dynamics friction="100" damping="100" />
      <axis xyz="1 0 0"/>
      <!-- <limit effort="100" velocity="100"/> -->
   </joint>
 
-  <link name="${name}_finger_left">
+  <link name="${name}_finger_left_link">
       <inertial>
           <mass value="0.1" />
           <origin xyz="0 0 0" />
@@ -155,7 +155,7 @@
      <limit lower="0.0027" upper="0.055" effort="1.0" velocity="0.42"/>
      <origin xyz="0 0 0" rpy="0 0 3.14159" />
      <parent link="${name}_base_link"/>
-     <child link="${name}_gripper_right" />
+     <child link="${name}_gripper_right_link" />
      <axis xyz="-1 0 0"/>
      <dynamics friction="100" damping="100" />
      <!-- <limit effort="100" velocity="100"/>-->
@@ -168,7 +168,7 @@
      <motorTorqueConstant>1</motorTorqueConstant>
   </transmission>
 	
-    <link name="${name}_gripper_right">
+    <link name="${name}_gripper_right_link">
       <inertial>
           <mass value="0.1" />
           <origin xyz="0 0 0" />
@@ -207,14 +207,14 @@
 
   <joint name="${name}_guide_joint_finger_right" type="fixed">
      <origin xyz="0 0 0.023" rpy="0 0 0" />
-     <parent link="${name}_gripper_right"/>
-     <child link="${name}_finger_right" />
+     <parent link="${name}_gripper_right_link"/>
+     <child link="${name}_finger_right_link" />
      <dynamics friction="100" damping="100" />
      <axis xyz="1 0 0"/>
      <limit effort="100" velocity="100"/>
   </joint>
 
-  <link name="${name}_finger_right">
+  <link name="${name}_finger_right_link">
       <inertial>
           <mass value="0.1" />
           <origin xyz="0 0 0" />

--- a/iai_wsg_50_description/urdf/wsg_50.urdf.xacro
+++ b/iai_wsg_50_description/urdf/wsg_50.urdf.xacro
@@ -51,7 +51,7 @@
 
   <!-- GRIPPER LEFT -->
 
-  <joint name="${name}_base_joint_gripper_left" type="prismatic">
+  <joint name="${name}_base_gripper_left_joint" type="prismatic">
      <limit lower="-0.055" upper="-0.0027" effort="1.0" velocity="0.42"/>
      <origin xyz="0 0 0" rpy="0 0 0" />      <!--origin xyz="-0.0067 0 0.049" rpy="0 0 0" /-->
      <parent link="${name}_base_link"/>
@@ -63,7 +63,7 @@
 
   <transmission name="${name}_base_trans_left" type="pr2_mechanism_model/SimpleTransmission">
      <actuator name="${name}_base_motor_left" />
-     <joint name="${name}_base_joint_gripper_left" />
+     <joint name="${name}_base_gripper_left_joint" />
      <mechanicalReduction>1</mechanicalReduction>
      <motorTorqueConstant>1</motorTorqueConstant>
   </transmission>
@@ -151,7 +151,7 @@
 
   <!-- GRIPPER RIGHT -->
 
-  <joint name="${name}_base_joint_gripper_right" type="prismatic">
+  <joint name="${name}_base_gripper_right_joint" type="prismatic">
      <limit lower="0.0027" upper="0.055" effort="1.0" velocity="0.42"/>
      <origin xyz="0 0 0" rpy="0 0 3.14159" />
      <parent link="${name}_base_link"/>
@@ -163,7 +163,7 @@
 
   <transmission name="${name}_base_trans_right" type="pr2_mechanism_model/SimpleTransmission">
      <actuator name="${name}_base_motor_right" />
-     <joint name="${name}_base_joint_gripper_right" />
+     <joint name="${name}_base_gripper_right_joint" />
      <mechanicalReduction>1</mechanicalReduction>
      <motorTorqueConstant>1</motorTorqueConstant>
   </transmission>


### PR DESCRIPTION
Few minors fix:
 * Name convention inconsistency for gripper model/controller implementation
   - renaming joint names, suffix for joint should be "_joint"
 * fix error wsg_50_msgs.msg module not found in boxy configurator script,
     maybe caused by a pkg renaming.