### PR TITLE
used .stl instead of .dae for kuka_lwr_arm.urdf

### DIFF
--- a/iai_kuka_lwr4_description/urdf/kuka_lwr_arm.urdf.xacro
+++ b/iai_kuka_lwr4_description/urdf/kuka_lwr_arm.urdf.xacro
@@ -36,8 +36,8 @@
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>
           <!-- for each mesh we have two versions, one Collada file with normals and colors, and one simpler STL. The collada file is in cm, and the STL in meters -->
-          <mesh filename="package://iai_kuka_lwr4_description/meshes/arm_base.dae" scale="100 100 100"/>
-	  <!--mesh filename="package://iai_kuka_lwr4_description/meshes/arm_base.stl" scale="1 1 1"-->
+          <!-- <mesh filename="package://iai_kuka_lwr4_description/meshes/arm_base.dae" scale="100 100 100"/> -->
+	  		<mesh filename="package://iai_kuka_lwr4_description/meshes/arm_base.stl" scale="1 1 1"/>
         </geometry>
         <material name="UniHB-Red"/>
       </visual>
@@ -79,8 +79,8 @@
       <visual>
         <origin xyz="0 0 0" rpy="0 0 ${M_PI}"/>
         <geometry>
-          <mesh filename="package://iai_kuka_lwr4_description/meshes/arm_segment_a.dae" scale="100 100 100"/>
-          <!--mesh filename="package://iai_kuka_lwr4_description/meshes/arm_segment_a.stl" scale="1 1 1"/-->
+          <!-- <mesh filename="package://iai_kuka_lwr4_description/meshes/arm_segment_a.dae" scale="100 100 100"/> -->
+          <mesh filename="package://iai_kuka_lwr4_description/meshes/arm_segment_a.stl" scale="1 1 1"/>
         </geometry>
         <material name="UniHB-Red"/>
       </visual>
@@ -129,8 +129,8 @@
       <visual>
         <origin xyz="0 0 0.2" rpy="${M_PI} 0 ${M_PI}"/>
         <geometry>
-          <mesh filename="package://iai_kuka_lwr4_description/meshes/arm_segment_b.dae" scale="100 100 100"/>
-          <!--mesh filename="package://iai_kuka_lwr4_description/meshes/arm_segment_b.stl" scale="1 1 1"/-->
+          <!-- <mesh filename="package://iai_kuka_lwr4_description/meshes/arm_segment_b.dae" scale="100 100 100"/> -->
+          <mesh filename="package://iai_kuka_lwr4_description/meshes/arm_segment_b.stl" scale="1 1 1"/>
         </geometry>
         <material name="UniHB-Red"/>
       </visual>
@@ -179,8 +179,8 @@
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>
-          <mesh filename="package://iai_kuka_lwr4_description/meshes/arm_segment_a.dae" scale="100 100 100"/>
-          <!--mesh filename="package://iai_kuka_lwr4_description/meshes/arm_segment_a.stl" scale="1 1 1"/-->
+          <!-- <mesh filename="package://iai_kuka_lwr4_description/meshes/arm_segment_a.dae" scale="100 100 100"/> -->
+          <mesh filename="package://iai_kuka_lwr4_description/meshes/arm_segment_a.stl" scale="1 1 1"/>
         </geometry>
         <material name="UniHB-Red"/>
       </visual>
@@ -229,8 +229,8 @@
       <visual>
         <origin xyz="0 0 0.2" rpy="0 ${M_PI} ${M_PI}"/>
         <geometry>
-          <mesh filename="package://iai_kuka_lwr4_description/meshes/arm_segment_b.dae" scale="100 100 100"/>
-          <!--mesh filename="package://iai_kuka_lwr4_description/meshes/arm_segment_b.stl" scale="1 1 1"/-->
+          <!-- <mesh filename="package://iai_kuka_lwr4_description/meshes/arm_segment_b.dae" scale="100 100 100"/> -->
+          <mesh filename="package://iai_kuka_lwr4_description/meshes/arm_segment_b.stl" scale="1 1 1"/>
         </geometry>
         <material name="UniHB-Red"/>
       </visual>
@@ -279,8 +279,8 @@
       <visual>
         <origin xyz="0 0 0" rpy="0 0 ${M_PI}"/>
         <geometry name="${name}_arm_5_geom">
-          <mesh filename="package://iai_kuka_lwr4_description/meshes/arm_segment_last.dae" scale="100 100 100"/> 
-          <!--mesh filename="package://iai_kuka_lwr4_description/meshes/arm_segment_last.stl" scale="1 1 1"/-->
+          <!-- <mesh filename="package://iai_kuka_lwr4_description/meshes/arm_segment_last.dae" scale="100 100 100"/>  -->
+          <mesh filename="package://iai_kuka_lwr4_description/meshes/arm_segment_last.stl" scale="1 1 1"/>
         </geometry>
         <material name="UniHB-Red"/>
       </visual>
@@ -329,8 +329,8 @@
       <visual>
         <origin xyz="0 0 0" rpy="0 0 ${M_PI}"/>
         <geometry>
-          <mesh filename="package://iai_kuka_lwr4_description/meshes/arm_wrist.dae" scale="100 100 100"/>
-          <!--mesh filename="package://iai_kuka_lwr4_description/meshes/arm_wrist.stl" scale="1 1 1"/-->
+          <!-- <mesh filename="package://iai_kuka_lwr4_description/meshes/arm_wrist.dae" scale="100 100 100"/> -->
+          <mesh filename="package://iai_kuka_lwr4_description/meshes/arm_wrist.stl" scale="1 1 1"/>
         </geometry>
         <material name="Grey"/>
       </visual>
@@ -378,8 +378,8 @@
       <visual>
         <origin xyz="0 0 0.078" rpy="0 0 0"/>
         <geometry>
-          <mesh filename="package://iai_kuka_lwr4_description/meshes/arm_flanche.dae" scale="100 100 100"/>
-          <!--mesh filename="package://iai_kuka_lwr4_description/meshes/arm_flanche.stl" scale="1 1 1"/-->
+          <!-- <mesh filename="package://iai_kuka_lwr4_description/meshes/arm_flanche.dae" scale="100 100 100"/> -->
+          <mesh filename="package://iai_kuka_lwr4_description/meshes/arm_flanche.stl" scale="1 1 1"/>
         </geometry>
         <material name="Black"/>
       </visual>


### PR DESCRIPTION
When testing the boxy simulation with indigo noticed, that the arms are not displayed in rviz. This problem does not occur with hydro. It seems to just be a visual problem, since rviz didn't show any errors and the simulation worked. 
![boxy_without_fix](https://cloud.githubusercontent.com/assets/4130471/9637201/ba1fa6a2-519f-11e5-8f50-cb0e1f1a5f74.png)

I fixed this by using .stl meshes of the arm parts (which are already in the package) instead of the .dae.
![boxy_fix](https://cloud.githubusercontent.com/assets/4130471/9637208/bd8a4446-519f-11e5-9c5d-47ac1c3ad2a5.png)

By the why, I'm unable to parse the urdf in python because 
\<calibration rising="0.0"/\> 
(for example used in iai_kuka_lwr4_description/urdf/kuka_lwr_arm.urdf.xacro line 66)
has no "falling" member. Adding falling="0.0" works, but I didn't include it into the pull request, because I don't know appropriate values for that.