### PR TITLE
Add xacro symlink for boxys base urdf

### DIFF
--- a/iai_boxy_base/launch/upload.launch
+++ b/iai_boxy_base/launch/upload.launch
@@ -1,0 +1,8 @@
+<launch>
+  <arg name="urdf-name" default="base.URDF.xacro"/>
+  <arg name="urdf-path" default="$(find iai_boxy_base)/robots/$(arg urdf-name)"/>
+  <arg name="param-name" default="robot_description"/>
+
+  <param name="$(arg param-name)" command="$(find xacro)/xacro.py '$(arg urdf-path)'" />
+</launch>
+

--- a/iai_boxy_base/robots/base.URDF.xacro
+++ b/iai_boxy_base/robots/base.URDF.xacro
@@ -1,0 +1,1 @@
+base.URDF


### PR DESCRIPTION
This makes it possible to load boxy's base without its extra components.