### PR TITLE
Boxy noetic

### DIFF
--- a/iai_kuka_lwr4_description/defs/util_defs.xml
+++ b/iai_kuka_lwr4_description/defs/util_defs.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0"?>
 <robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
        xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface">
+       xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+       xmlns:xacro="http://www.ros.org/wiki/xacro">
 
   <property name="M_PI" value="3.1415926535897931" />
 
@@ -9,19 +10,19 @@
      Little helper macro to define the inertia matrix needed
      for links.
      -->
-  <macro name="cuboid_inertia_def" params="width height length mass">
+  <xacro:macro name="cuboid_inertia_def" params="width height length mass">
     <inertia ixx="${mass * (height * height + length * length) / 12}"
              iyy="${mass * (width * width + length * length) / 12}"
              izz="${mass * (width * width + height * height) / 12}"
              ixy="0" iyz="0" ixz="0"/>
-  </macro>
+  </xacro:macro>
 
   <!-- length is along the y-axis! -->
-  <macro name="cylinder_inertia_def" params="radius length mass">
+  <xacro:macro name="cylinder_inertia_def" params="radius length mass">
     <inertia ixx="${mass * (3 * radius * radius + length * length) / 12}"
              iyy="${mass * radius* radius / 2}"
              izz="${mass * (3 * radius * radius + length * length) / 12}"
              ixy="0" iyz="0" ixz="0"/>
-  </macro>
+  </xacro:macro>
 
 </robot>


### PR DESCRIPTION
# Description
Added the xacro namespace to the utils of the kuka_lwr4_description to make it compatible with xacro in ROS noetic.