### PR TITLE
Adjusted Gripper alignment + CI fixes for cram

### DIFF
--- a/iai_daisy_description/CMakeLists.txt
+++ b/iai_daisy_description/CMakeLists.txt
@@ -2,8 +2,7 @@ cmake_minimum_required(VERSION 3.10)
 project(iai_daisy_description)
 
 find_package(ament_cmake REQUIRED)
-find_package(ur_client_library REQUIRED)
-find_package(griplink REQUIRED)
+
 install(DIRECTORY launch config robots meshes
   DESTINATION share/${PROJECT_NAME})
 

--- a/iai_daisy_description/robots/daisy.urdf.xacro
+++ b/iai_daisy_description/robots/daisy.urdf.xacro
@@ -122,14 +122,14 @@
 
   <link name="left_gripper_mounting_plate">
     <visual>
-      <origin xyz="0 0 0" rpy="0 0 ${pi/2}"/>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
       <geometry>
         <mesh filename="package://iai_daisy_description/meshes/FL-ISO50-WPG300_WITH_FILLET.stl" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="Cyan"/>
     </visual>
     <collision>
-      <origin xyz="0 0 0" rpy="0 0 ${pi/2}"/>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
       <geometry>
         <mesh filename="package://iai_daisy_description/meshes/FL-ISO50-WPG300_WITH_FILLET.stl" scale="0.001 0.001 0.001"/>
       </geometry>
@@ -139,11 +139,11 @@
   <joint name="left_gripper_mounting_plate_joint" type="fixed">
     <parent link="left_flange"/>
     <child link="left_gripper_mounting_plate"/>
-    <origin xyz="0 0 0.005" rpy="${pi/2} 0 ${pi/2}"/>
+    <origin xyz="0 0 0.005" rpy="0 ${pi/2} 0"/>
   </joint>
 
   <xacro:wsg_300_120_xacro parent="left_gripper_mounting_plate" name="left_gripper">
-    <origin xyz="0 0 0" rpy="0 0 -${pi/2}"/>
+    <origin xyz="0 0 0" rpy="0 0 0"/>
   </xacro:wsg_300_120_xacro>
 
   <joint name="right_arm_mounting_plate_joint" type="fixed">
@@ -178,13 +178,13 @@
 
   <link name="right_gripper_mounting_plate">
     <visual>
-      <origin xyz="0 0 0" rpy="0 0 ${pi/2}"/>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
       <geometry>
         <mesh filename="package://iai_daisy_description/meshes/FL-ISO50-WPG300_WITH_FILLET.stl" scale="0.001 0.001 0.001"/>
       </geometry>
     </visual>
     <collision>
-      <origin xyz="0 0 0" rpy="0 0 ${pi/2}"/>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
       <geometry>
         <mesh filename="package://iai_daisy_description/meshes/FL-ISO50-WPG300_WITH_FILLET.stl" scale="0.001 0.001 0.001"/>
       </geometry>
@@ -194,11 +194,11 @@
   <joint name="right_gripper_mounting_plate_joint" type="fixed">
     <parent link="right_flange"/>
     <child link="right_gripper_mounting_plate"/>
-    <origin xyz="0 0 0.005" rpy="${pi/2} 0 ${pi/2}"/>
+    <origin xyz="0 0 0.005" rpy="0 ${pi/2} 0"/>
   </joint>
 
   <xacro:wsg_300_120_xacro parent="right_gripper_mounting_plate" name="right_gripper">
-    <origin xyz="0 0 0" rpy="0 0 -${pi/2}"/>
+    <origin xyz="0 0 0" rpy="0 0 0"/>
   </xacro:wsg_300_120_xacro>
 
   <link name="left_gripper_left_finger_tip_link">


### PR DESCRIPTION
Adjusted gripper alignment to work with interactive markers correctly.
Removed griplink and ur_client_library from CMakeList.txt as they are not build dependencies. They are still in the package.xml as execution dependencies.